### PR TITLE
Exclude jspecify dependency from guava to avoid transitive issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,10 @@
 					<groupId>com.google.errorprone</groupId>
 					<artifactId>error_prone_annotations</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.jspecify</groupId>
+					<artifactId>jspecify</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This pull request includes a minor update to the `pom.xml` file. The change adds an exclusion for the `jspecify` artifact under the `org.jspecify` group to the list of exclusions for a dependency.