### PR TITLE
Bump plugin and dependencies to OpenSearch 3.1.0 and Lucene 10.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-minhash</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>
 		An OpenSearch plugin that provides b-bit MinHash algorithm support for efficient similarity detection and approximate nearest neighbor search. Useful for deduplication, clustering, and large-scale similarity analysis in OpenSearch indices.
@@ -38,11 +38,11 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.0.0</opensearch.version>
-		<opensearch.runner.version>3.0.0.0</opensearch.runner.version>
+		<opensearch.version>3.1.0</opensearch.version>
+		<opensearch.runner.version>3.1.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.1.0</lucene.version>
+		<lucene.version>10.2.1</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
This pull request updates the project dependencies and versioning in the `pom.xml` file to align with the latest OpenSearch and Lucene versions. These changes ensure compatibility with newer features and improvements in the respective libraries.

### Dependency and version updates:

* Updated the project version from `3.0.1-SNAPSHOT` to `3.1.0-SNAPSHOT` to reflect the new release cycle. (`pom.xml`, [pom.xmlL7-R7](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7))
* Updated OpenSearch-related properties:
  - Changed `opensearch.version` from `3.0.0` to `3.1.0`.
  - Changed `opensearch.runner.version` from `3.0.0.0` to `3.1.0.0`. (`pom.xml`, [pom.xmlL41-R45](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L41-R45))
* Updated `lucene.version` from `10.1.0` to `10.2.1` for compatibility with the latest Lucene improvements. (`pom.xml`, [pom.xmlL41-R45](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L41-R45))