### PR TITLE
Bump OpenSearch and Lucene versions to 3.2.0 and 10.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-minhash</artifactId>
-	<version>3.1.1-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>
 		An OpenSearch plugin that provides b-bit MinHash algorithm support for efficient similarity detection and approximate nearest neighbor search. Useful for deduplication, clustering, and large-scale similarity analysis in OpenSearch indices.
@@ -38,11 +38,11 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.1.0</opensearch.version>
-		<opensearch.runner.version>3.1.0.0</opensearch.runner.version>
+		<opensearch.version>3.2.0</opensearch.version>
+		<opensearch.runner.version>3.2.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.2.1</lucene.version>
+		<lucene.version>10.2.2</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
This PR updates the project dependencies and versioning to align with the latest OpenSearch release.

- Updated project version from `3.1.1-SNAPSHOT` to `3.2.0-SNAPSHOT`.
- Bumped `opensearch.version` from `3.1.0` to `3.2.0`.
- Bumped `opensearch.runner.version` from `3.1.0.0` to `3.2.0.0`.
- Upgraded `lucene.version` from `10.2.1` to `10.2.2`.

These updates ensure compatibility with the latest OpenSearch **3.2** release and improvements from the Lucene **10.2.2** bugfix release.