### PR TITLE
chore: update OpenSearch to 3.3.0 and Lucene to 10.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-minhash</artifactId>
-	<version>3.2.1-SNAPSHOT</version>
+	<version>3.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>
 		An OpenSearch plugin that provides b-bit MinHash algorithm support for efficient similarity detection and approximate nearest neighbor search. Useful for deduplication, clustering, and large-scale similarity analysis in OpenSearch indices.
@@ -38,11 +38,11 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.2.0</opensearch.version>
-		<opensearch.runner.version>3.2.0.0</opensearch.runner.version>
+		<opensearch.version>3.3.0</opensearch.version>
+		<opensearch.runner.version>3.3.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.2.2</lucene.version>
+		<lucene.version>10.3.1</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
  ## Summary
  This PR updates OpenSearch and Lucene dependencies to their latest versions to maintain compatibility with the OpenSearch 3.3.0 release.

  ## Changes Made
  - Updated OpenSearch from 3.2.0 to 3.3.0
  - Updated Lucene from 10.2.2 to 10.3.1
  - Bumped plugin version from 3.2.1-SNAPSHOT to 3.3.0-SNAPSHOT
  - Updated OpenSearch runner version to 3.3.0.0

  ## Testing
  - Build verification recommended: \`mvn clean package\`
  - Unit tests should pass: \`mvn test\`

  ## Breaking Changes
  None expected. This is a standard dependency update following the OpenSearch release cycle.

  ## Additional Notes
  This update maintains alignment with the latest OpenSearch ecosystem releases.