### PR TITLE
chore: update OpenSearch to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.3.0</opensearch.version>
-		<opensearch.runner.version>3.3.0.0</opensearch.runner.version>
+		<opensearch.version>3.3.2</opensearch.version>
+		<opensearch.runner.version>3.3.2.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<lucene.version>10.3.1</lucene.version>


### PR DESCRIPTION
## Summary

This PR updates the OpenSearch dependency from version 3.3.0 to 3.3.2, along with the corresponding runner version update.

## Changes Made

- Updated `opensearch.version` property from `3.3.0` to `3.3.2` in pom.xml
- Updated `opensearch.runner.version` property from `3.3.0.0` to `3.3.2.0` in pom.xml

## Testing

- Build verification should be performed to ensure compatibility with OpenSearch 3.3.2
- Existing unit tests should pass without modification

## Breaking Changes

None expected. This is a minor version update that should be backward compatible.

## Additional Notes

This update keeps the plugin aligned with the latest OpenSearch 3.3.x release, ensuring compatibility and access to any bug fixes or improvements in the 3.3.2 release.