### PR TITLE
chore: update OpenSearch to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-minhash</artifactId>
-	<version>3.3.2-SNAPSHOT</version>
+	<version>3.4.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>
 		An OpenSearch plugin that provides b-bit MinHash algorithm support for efficient similarity detection and approximate nearest neighbor search. Useful for deduplication, clustering, and large-scale similarity analysis in OpenSearch indices.
@@ -38,11 +38,11 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.3.2</opensearch.version>
-		<opensearch.runner.version>3.3.2.0</opensearch.runner.version>
+		<opensearch.version>3.4.0</opensearch.version>
+		<opensearch.runner.version>3.4.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.3.1</lucene.version>
+		<lucene.version>10.3.2</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -17,7 +17,6 @@
 			<useTransitiveFiltering>true</useTransitiveFiltering>
 			<excludes>
 				<exclude>org.apache.lucene:lucene-analysis-common</exclude>
-				<exclude>org.codelibs.opensearch:opensearch-engine-server</exclude>
 			</excludes>
 		</dependencySet>
 	</dependencySets>


### PR DESCRIPTION
## Summary
Update project dependencies to align with OpenSearch 3.4.0 release.

## Changes Made
- Bump OpenSearch version from 3.3.2 to 3.4.0
- Bump opensearch-runner from 3.3.2.0 to 3.4.0.0
- Bump Lucene from 10.3.1 to 10.3.2
- Update project version to 3.4.0-SNAPSHOT
- Remove `opensearch-engine-server` exclusion from plugin assembly (no longer needed)

## Testing
- Build and test with `mvn clean verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)