### PR TITLE
chore: update OpenSearch to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-minhash</artifactId>
-	<version>3.4.1-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>
 		An OpenSearch plugin that provides b-bit MinHash algorithm support for efficient similarity detection and approximate nearest neighbor search. Useful for deduplication, clustering, and large-scale similarity analysis in OpenSearch indices.
@@ -38,12 +38,12 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.4.0</opensearch.version>
-		<opensearch.runner.version>3.4.0.0</opensearch.runner.version>
+		<opensearch.version>3.5.0</opensearch.version>
+		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<lucene.version>10.3.2</lucene.version>
-		<log4j.version>2.21.0</log4j.version>
+		<log4j.version>2.25.3</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>


### PR DESCRIPTION
## Summary
- Update OpenSearch version from 3.4.0 to 3.5.0
- Update OpenSearch Runner version from 3.4.0.0 to 3.5.0.0
- Update plugin version from 3.4.1-SNAPSHOT to 3.5.0-SNAPSHOT
- Update log4j version from 2.21.0 to 2.25.3

## Test plan
- [ ] Verify `mvn clean package` builds successfully
- [ ] Verify `mvn test` passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)