### PR TITLE
chore: update OpenSearch to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-minhash</artifactId>
-	<version>3.5.1-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>
 		An OpenSearch plugin that provides b-bit MinHash algorithm support for efficient similarity detection and approximate nearest neighbor search. Useful for deduplication, clustering, and large-scale similarity analysis in OpenSearch indices.
@@ -38,11 +38,11 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.5.0</opensearch.version>
-		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
+		<opensearch.version>3.6.0</opensearch.version>
+		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.3.2</lucene.version>
+		<lucene.version>10.4.0</lucene.version>
 		<log4j.version>2.25.3</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
## Summary
Update dependency versions to align with OpenSearch 3.6.0 release.

## Changes Made
- Bump OpenSearch version from 3.5.0 to 3.6.0
- Bump OpenSearch Runner version from 3.5.0.0 to 3.6.0.0
- Bump Lucene version from 10.3.2 to 10.4.0
- Update plugin version to 3.6.0-SNAPSHOT

## Testing
- Build and run unit tests with `mvn clean test`
- Verify plugin packaging with `mvn clean package assembly:single`

## Breaking Changes
- None

## Additional Notes
- Routine version bump to track the latest OpenSearch release