### PR TITLE
chore: update OpenSearch to 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The plugin integrates seamlessly with OpenSearch's analysis pipeline through thr
 
 | Plugin Version | OpenSearch Version | Java Version | Lucene Version |
 |---------------|--------------------|--------------|----------------|
-| 3.2.x         | 3.2.0              | 21+          | 10.2.2         |
+| 3.7.x         | 3.7.0              | 21+          | 10.4.0         |
 
 [📦 All Versions in Maven Repository](https://repo1.maven.org/maven2/org/codelibs/opensearch/opensearch-minhash/)
 
@@ -37,7 +37,7 @@ The plugin integrates seamlessly with OpenSearch's analysis pipeline through thr
 ### Quick Install from Maven Central
 
 ```bash
-$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-minhash:3.2.0
+$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-minhash:3.7.0
 ```
 
 ### Build and Install from Source
@@ -51,7 +51,7 @@ cd opensearch-minhash
 mvn clean package
 
 # Install from local build
-$OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-minhash-3.2.1-SNAPSHOT.zip
+$OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-minhash-3.7.0-SNAPSHOT.zip
 
 # Restart OpenSearch
 $OPENSEARCH_HOME/bin/opensearch-node restart
@@ -342,7 +342,7 @@ curl -XGET "localhost:9200/documents/_search?pretty" -H 'Content-Type: applicati
 
 - **Java 21+**: OpenJDK or Oracle JDK
 - **Maven 3.6+**: Build automation
-- **OpenSearch 3.2.0**: Target platform
+- **OpenSearch 3.7.0**: Target platform
 
 ### Project Structure
 
@@ -416,7 +416,7 @@ mvn test -X
 5. **Install for Testing**:
    ```bash
    $OPENSEARCH_HOME/bin/opensearch-plugin remove opensearch-minhash  # Remove old version
-   $OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-minhash-3.2.1-SNAPSHOT.zip
+   $OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-minhash-3.7.0-SNAPSHOT.zip
    ```
 
 ### Code Style Guidelines

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-minhash</artifactId>
-	<version>3.6.1-SNAPSHOT</version>
+	<version>3.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>
 		An OpenSearch plugin that provides b-bit MinHash algorithm support for efficient similarity detection and approximate nearest neighbor search. Useful for deduplication, clustering, and large-scale similarity analysis in OpenSearch indices.
@@ -38,8 +38,8 @@
       <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.6.0</opensearch.version>
-		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
+		<opensearch.version>3.7.0</opensearch.version>
+		<opensearch.runner.version>3.7.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.minhash.MinHashPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<lucene.version>10.4.0</lucene.version>


### PR DESCRIPTION
## Summary
Updates the plugin to OpenSearch 3.7.0, following the same pattern as the 3.6.0 update (#12).

## Changes Made
- Bump OpenSearch version from 3.6.0 to 3.7.0
- Bump OpenSearch Runner version from 3.6.0.0 to 3.7.0.0
- Update plugin version to 3.7.0-SNAPSHOT
- Lucene stays at 10.4.0 since OpenSearch 3.7.0 uses the same Lucene version as 3.6.0 (verified against opensearch-core-3.7.0.pom on Maven Central)
- Update stale version references in README.md (compatibility table and install examples were still pointing at 3.2.x)

## Testing
- `mvn clean package` builds successfully against OpenSearch 3.7.0
- All 22 unit tests pass (MinHashPluginTest, MinHashTokenFilterFactoryTest, MinHashFieldMapperTest)
- Plugin distribution zip is generated as expected

## Breaking Changes
- None

## Additional Notes
- No source code changes were required for 3.7.0 compatibility