### PR TITLE
build: attach sources and javadoc jars to release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,18 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.11.2</version>
 				<configuration>
@@ -74,6 +86,14 @@
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>


### PR DESCRIPTION
## Summary
Release builds via `release:perform` were not producing sources and javadoc jars, so they were missing from artifacts published to Maven Central. This is the same issue fixed in codelibs/opensearch-runner#20.

The release-profile in the Maven super POM that used to attach these jars automatically is no longer available in current Maven versions, so the executions need to be configured explicitly.

## Changes Made
- Added `maven-source-plugin` 3.3.1 with an `attach-sources` execution (`jar-no-fork` goal)
- Added an `attach-javadocs` execution (`jar` goal) to the existing `maven-javadoc-plugin` configuration

## Testing
- Ran `mvn package -DskipTests=true -Dgpg.skip=true` and confirmed that `opensearch-minhash-3.7.0-SNAPSHOT-sources.jar` and `opensearch-minhash-3.7.0-SNAPSHOT-javadoc.jar` are generated in `target/` alongside the main jar

## Additional Notes
- Same fix as applied to opensearch-runner in codelibs/opensearch-runner@25c54af